### PR TITLE
ci: fix pip-audit step; stop runtime floor-raise PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,16 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    # Runtime dependencies are declared as minimum-version floors in
+    # [project].dependencies; raising a floor forces every downstream installer
+    # onto the newer release, so floors are raised deliberately when a feature
+    # or fix requires it — not on release cadence. Only dev/CI tooling updates
+    # are proposed automatically.
+    ignore:
+      - dependency-name: "numpy"
+      - dependency-name: "fortranformat"
+      - dependency-name: "json-stream"
+      - dependency-name: "rms-*"
 
   - package-ecosystem: github-actions
     directory: /

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -47,9 +47,10 @@ jobs:
         run: |
           python -m pyroma .
 
-      - name: pip audit (dependency vulnerabilities)
+      - name: pip-audit (dependency vulnerabilities)
         run: |
-          pip audit
+          python -m pip install --upgrade pip setuptools
+          pip-audit --skip-editable
 
       - name: Sphinx
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ dev = [
   "ruff>=0.8",
   "types-PyYAML",
   "bandit[toml]>=1.8",
+  "pip-audit>=2.7",
   "pyroma>=4.2",
   "vulture>=2.14",
   "rms-metadata-tools[docs]",


### PR DESCRIPTION
Two CI/dependency housekeeping fixes surfaced by the first Dependabot sweep:

## 1. The Lint job has been red on every branch since #124

The audit step ran `pip audit` — not a pip subcommand — and `pip-audit` was never installed, so the step errored with `unknown command "audit"` on every run. Fixed by:
- adding `pip-audit>=2.7` to the dev extra (the Lint job installs `.[dev]`),
- invoking `pip-audit --skip-editable` (the editable self-install can't be audited),
- upgrading `pip`/`setuptools` in the job first — verified locally that the runner-provided setuptools 82 otherwise trips PYSEC-2026-3447 and would keep the step red for an unrelated reason.

Note: `pip-audit` is CI-only (network-dependent), so it intentionally has no `run-all-checks.sh` counterpart.

## 2. Dependabot no longer proposes runtime floor raises

The first sweep filed 13 PRs; five of them raised minimum-version floors on runtime dependencies (`numpy>=2.4.6` etc.). For a published library, a floor raise forces every downstream installer onto the newer release, so floors should move deliberately (when a feature/fix is needed), not on release cadence. Those five PRs were closed (#131–#133, #136, #137); this config ignores runtime deps (`numpy`, `fortranformat`, `json-stream`, `rms-*`) while keeping dev/CI tooling and GitHub Actions updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhL2gSUum6zECag4iLrWh1